### PR TITLE
Feature/createElement

### DIFF
--- a/src/createElement/createElement.ts
+++ b/src/createElement/createElement.ts
@@ -1,10 +1,10 @@
 import {VNode, Children} from '../types/vnode'
 
-function createElement(
+function createElement<T ={}>(
   type: VNode["type"],
-  props: VNode["props"],
+  props: VNode["props"] & T,
   ...children: Children
-): VNode {
+): VNode<T> {
   const actualChildren = children.length ? children : []
   return {
     type: type,

--- a/src/types/vnode.ts
+++ b/src/types/vnode.ts
@@ -11,6 +11,6 @@ type AllowedChildrenType =
 	| null
 	| undefined;
 
-export type Children = AllowedChildrenType[]
+export type Children = AllowedChildrenType[] 
 
 

--- a/test/unit/createElement/createElement.spec.ts
+++ b/test/unit/createElement/createElement.spec.ts
@@ -13,12 +13,12 @@ describe("Testing createElement function, it return a vnode", () => {
     expect(createElement("div", props)).toEqual(expectedVNode);
   });
 
-  it("createElement return VNode where children is array that contain a primitive", () => {
-    const expectedVNode: VNode = {
+  it("createElement return VNode where props contain specified attribute ", () => {
+    const expectedVNode: VNode<{id: "Alelí"}> = {
       type: "div",
-      props: { children: ["Hello"] },
+      props: { children: ["Hello"], id: "Alelí" },
     };
-    expect(createElement("div", {}, "Hello")).toEqual(expectedVNode);
+    expect(createElement("div", {id: "Alelí"}, "Hello")).toHaveProperty('props.id',"Alelí");
   });
 
   it("createElement return VNode where children is array that contain VNode", () => {


### PR DESCRIPTION
Fix the issue that prevent to specify other props than children.
createElement function now is a generic function that infer passed generic intersected with VNode type