### PR TITLE
Feature/render

### DIFF
--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -6,6 +6,10 @@ export default class AleliRenderer implements Renderer {
   render(node: VNode, root: CustomHTMLElement): void {
     if(Array<number>(Node.TEXT_NODE, Node.COMMENT_NODE).indexOf(root.nodeType) == -1){
       if(!root._vnode) root._vnode = { type: "", props: { children: [] } };
+      if(node.type !== root._vnode.type){
+        root._vnode.dom && root._vnode.dom.remove()
+        root._vnode = { type: "", props: { children: [] } };
+      }
       this.diff(node, root, root._vnode);
     }
     else{

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -5,9 +5,8 @@ import { isVNode, isNotTextNode } from "@src/utils/detectNodeUtils";
 export default class AleliRenderer implements Renderer {
   render(node: VNode, root: CustomHTMLElement): void {
     if(Array<number>(Node.TEXT_NODE, Node.COMMENT_NODE).indexOf(root.nodeType) == -1){
-      if(!root._vnode) root._vnode = { type: "", props: { children: [] } };
-      if(node.type !== root._vnode.type){
-        root._vnode.dom && root._vnode.dom.remove()
+      if(!root._vnode || node.type !== root._vnode.type){
+        root._vnode && root._vnode.dom && root._vnode.dom.remove()
         root._vnode = { type: "", props: { children: [] } };
       }
       this.diff(node, root, root._vnode);

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -70,7 +70,7 @@ export default class AleliRenderer implements Renderer {
   ) {
     //Event listener attached with on<event> https://mzl.la/3rbCpxA
     const name: string = prop.startsWith("on") ? prop.toLowerCase() : prop;
-
+    if(prop === 'key') { return }
     if (prop in htmlElement) {
       htmlElement[name] = props[name];
     } else {

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -130,7 +130,16 @@ export default class AleliRenderer implements Renderer {
   ): VNode {
     return (
       (this.getOldChildren(oldNode).find((oldChild, oldChildindex) => {
-        return child.type === oldChild.type && index === oldChildindex;
+        let result = undefined
+        if(child.props.key && oldChild.props.key) {  
+          if((child.props.key === oldChild.props.key) && (child.type === oldChild.type)){
+           result = oldChild
+          }
+        }else {
+          if(child.type === oldChild.type && index === oldChildindex )
+            result = oldChild
+        }
+        return result
       }) as VNode) || { type: "", props: { children: [] } }
     );
   }

--- a/test/unit/render/render.private.spec.ts
+++ b/test/unit/render/render.private.spec.ts
@@ -56,4 +56,78 @@ describe("render method should call setProperty only when needed", () => {
     expect(spySetProperty).toBeCalledTimes(1)
   });
 
+  it("render shouldn't call create element if not necessary, using key attribute ", () => {
+    // @ts-ignore
+    const spyCreateElement = jest.spyOn(AleliRenderer.prototype, "createElement")
+
+    const vnode: VNode<{ className: "Alelí" }> = {
+          type: "div",
+          props: {
+            className: "Alelí",
+            children: [
+              {
+                type: "div",
+                props: {
+                  className: "First",
+                  key: 1,
+                  children: [],
+                },
+              },
+              {
+                type: "span",
+                props: {
+                  className: "Second",
+                  key: 2,
+                  children: [],
+                },
+              },
+              {
+                type: "button",
+                props: {
+                  className: "third",
+                  key: 3,
+                  children: [],
+                },
+              }
+            ],
+          },
+        };
+    const root: HTMLElement = document.createElement("div");
+    aleliRenderer.render(vnode, root);
+    const updatedVnode: VNode<{ className: "Alelí" }> = {
+      type: "div",
+      props: {
+        className: "Alelí",
+        children: [
+          {
+            type: "span",
+            props: {
+              className: "Second",
+              key: 2,
+              children: [],
+            },
+          },
+          {
+            type: "div",
+            props: {
+              className: "First",
+              key: 1,
+              children: [],
+            },
+          },
+          {
+            type: "button",
+            props: {
+              className: "third",
+              key: 3,
+              children: [],
+            },
+          }
+        ],
+      },
+    };
+    aleliRenderer.render(updatedVnode, root);
+    expect(spyCreateElement).toBeCalledTimes(4)
+  });
+
 })

--- a/test/unit/render/render.spec.ts
+++ b/test/unit/render/render.spec.ts
@@ -241,6 +241,32 @@ describe("Testing render function, it render VNodes", () => {
     );
   });
 
+  it("render should change parent dom node if change ", () => {
+    let vnode: VNode<{ className: "Alelí" }> = {
+          type: "div",
+          props: {
+            className: "Alelí",
+            children: [],
+          },
+        };
+    let root: HTMLElement = document.createElement("div");
+    aleliRenderer.render(vnode, root);
+    expect(serializer.serializeNode(root)).toEqual(
+      `<div><div class="Alelí"></div></div>`
+    );
+    let updatedVnode: VNode<{ className: "Alelí" }> = {
+      type: "span",
+      props: {
+        className: "Alelí",
+        children: [],
+      },
+    };
+    aleliRenderer.render(updatedVnode, root);
+    expect(serializer.serializeNode(root)).toEqual(
+      `<div><span class="Alelí"></span></div>`
+    );
+  });
+
   it("render should remove event listener div if needed", () => {
     let child : HTMLElement;
     const mocked : Function = () => {}

--- a/test/unit/render/render.spec.ts
+++ b/test/unit/render/render.spec.ts
@@ -342,5 +342,18 @@ describe("Testing render function, it render VNodes", () => {
     const root: Comment = document.createTextNode("Alelí Comment")
     expect(() => aleliRenderer.render(vnode, root as unknown as HTMLElement)).toThrowError('AleliRenderer, can\'t call render method on Text or Comment root node')
   });
+
+  it("render should not set key attribute", () => {
+    let vnode: VNode<{ key: 1 }> = {
+      type: "div",
+      props: { key: 1, children: [] },
+    };
+    let root: HTMLElement = document.createElement("div");
+    aleliRenderer.render(vnode, root);
+    expect(serializer.serializeNode(root)).toEqual(
+      `<div><div></div></div>`
+    );
+  });
+
  
 });


### PR DESCRIPTION
Add key attribute

If key attribute is specified, it will be used to find old children with same type and same key, this prevent render to destroy and recreate all dom nodes if the order of them change during renders